### PR TITLE
Add notice loaded/hidden events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 /vendor
+/composer.lock

--- a/src/web/assets/dist/js/notice.js
+++ b/src/web/assets/dist/js/notice.js
@@ -10,6 +10,7 @@ const WabiNotice = ($el) => {
       this.getCookie()
       this.$nextTick(() => {
         $el.classList.add('notice--loaded')
+        window.dispatchEvent(new CustomEvent('wabi:notice-loaded', { detail: { el: $el } }))
       })
     },
 
@@ -24,6 +25,7 @@ const WabiNotice = ($el) => {
     handleHide() {
       this.hidden = true;
       $el.classList.remove('notice--loaded')
+      window.dispatchEvent(new CustomEvent('wabi:notice-hidden', { detail: { el: $el } }))
       docCookies.setItem(`${this.keyName}`, false, this.time, '/')
     },
 


### PR DESCRIPTION
## Summary
- Dispatch `wabi:notice-loaded` when the notice bar finishes loading (after `notice--loaded` class is added)
- Dispatch `wabi:notice-hidden` when the user dismisses the notice bar
- Both events include `{ detail: { el } }` with the notice element reference

## Motivation
Sites using Blitz static caching load the notice bar via AJAX. When it slides in, it pushes the navigation down — but overlays that calculated their position before the bar loaded end up misaligned. These events let consuming sites listen and reposition.

## Usage
```js
window.addEventListener('wabi:notice-loaded', () => {
  // recalculate overlay position
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude a dependency lockfile from tracking.
  * Visible impact: repository view and change lists will no longer include that lockfile, reducing noise in commits and diffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->